### PR TITLE
upgrade opentracing-javascript to latest upstream

### DIFF
--- a/examples/01-app-no-tracing.js
+++ b/examples/01-app-no-tracing.js
@@ -121,6 +121,11 @@ server = restify.createServer({
     name: APP_NAME
 });
 
+server.on('uncaughtException', function (req, res, route, err) {
+    log.error(err);
+    res.send(err);
+});
+
 // This sets up to add req.log to all req objects
 server.use(restify.requestLogger());
 

--- a/examples/02-app-opentracing.js
+++ b/examples/02-app-opentracing.js
@@ -193,6 +193,11 @@ server.use(function startTracing(req, res, next) {
     next();
 });
 
+server.on('uncaughtException', function (req, res, route, err) {
+    log.error(err);
+    res.send(err);
+});
+
 // This sets up to add req.log to all req objects
 server.use(restify.requestLogger());
 

--- a/examples/03-app-simplified.js
+++ b/examples/03-app-simplified.js
@@ -141,6 +141,11 @@ server = restify.createServer({
 // Start the tracing backend and instrument this restify 'server'.
 Tracer.restifyServer.init({log: log, restifyServer: server});
 
+server.on('uncaughtException', function (req, res, route, err) {
+    log.error(err);
+    res.send(err);
+});
+
 // This sets up to add req.log to all req objects
 server.use(restify.requestLogger());
 

--- a/lib/ot-span-imp.js
+++ b/lib/ot-span-imp.js
@@ -150,6 +150,9 @@ TritonSpan.prototype.setFields = function setFields(fields) {
                 // addTags() validates value
                 self.addTags(value);
                 break;
+            case 'childOf':
+                self.setParentSpanId(value._spanId);
+                break;
             default:
                 assert.ok(!true, 'unknown field: fields.' + key);
                 break;
@@ -159,7 +162,6 @@ TritonSpan.prototype.setFields = function setFields(fields) {
 
 TritonSpan.prototype.setParentSpanId = function setParentSpanId(spanId) {
     var self = this;
-
     assert.uuid(spanId, 'spanId');
 
     self._parentSpanId = spanId;

--- a/lib/ot-tracer-imp.js
+++ b/lib/ot-tracer-imp.js
@@ -8,6 +8,7 @@
 
 var assert = require('assert-plus');
 var uuid = require('node-uuid');
+var opentracing = require('opentracing');
 
 var TritonConstants = require('./ot-constants');
 var TritonSpan = require('./ot-span-imp');
@@ -31,7 +32,7 @@ TritonTracer.prototype.setInterface = function setInterface(tracerInterface) {
     this._interface = tracerInterface;
 };
 
-TritonTracer.prototype.startSpan = function startSpan(fields) {
+TritonTracer.prototype.startSpan = function startSpan(name, fields) {
     var self = this;
     var idx;
     var parentCtx;
@@ -41,6 +42,7 @@ TritonTracer.prototype.startSpan = function startSpan(fields) {
     var spanId = uuid.v4();
     var traceId;
 
+    assert.string(name, 'name');
     assert.object(fields, 'fields');
     assert.optionalArray(fields.references, 'fields.references');
     assert.optionalObject(fields.continuationOf, 'fields.continuationOf');
@@ -63,7 +65,7 @@ TritonTracer.prototype.startSpan = function startSpan(fields) {
     } else if (fields.continuationOf) {
         // Joining an existing trace as either the first span (when value has no
         // _spanId) or also joining an existing span.
-        parentCtx = fields.continuationOf.imp();
+        parentCtx = fields.continuationOf;
         assert.uuid(parentCtx._traceId, 'parentCtx._traceId');
         if (parentCtx._spanId) {
             spanId = parentCtx._spanId;
@@ -77,6 +79,7 @@ TritonTracer.prototype.startSpan = function startSpan(fields) {
     spanCtx = new TritonSpanContext(spanId, traceId);
     span = new TritonSpan(self, spanCtx);
 
+    span.setOperationName(name);
     // TODO: Do we need to span.addTags() for the default tags? Or support
     //       default tags at all?
     span.setFields(fields);
@@ -98,7 +101,7 @@ TritonTracer.prototype.inject = function inject(spanCtx, format, carrier) {
     assert.object(spanCtx, 'spanCtx');
     assert.uuid(spanCtx._spanId, 'spanCtx._spanId');
     assert.uuid(spanCtx._traceId, 'spanCtx._traceId');
-    assert.equal(format, self._interface.FORMAT_TEXT_MAP, 'Unsupported format');
+    assert.equal(format, opentracing.FORMAT_TEXT_MAP, 'Unsupported format');
     assert.object(carrier, 'carrier');
 
     // We only support "TextMap" format which we assume for now is a restify

--- a/lib/ot-tracer-imp.js
+++ b/lib/ot-tracer-imp.js
@@ -146,12 +146,4 @@ TritonTracer.prototype.extract = function extract(format, carrier) {
     return (spanCtx);
 };
 
-TritonTracer.prototype.flush = function flush(callback) {
-    // Nothing to flush currently. So: SUCCESS!
-    if (callback) {
-        callback(null);
-        return;
-    }
-};
-
 module.exports = TritonTracer;

--- a/lib/restify-client.js
+++ b/lib/restify-client.js
@@ -7,6 +7,7 @@
 //
 
 var assert = require('assert-plus');
+var opentracing = require('opentracing');
 
 // Returns a restify client that's a child of oriClient but creates and logs a
 // span for every request made.
@@ -28,7 +29,7 @@ function child(oriClient, req, clientName) {
             var tracer;
 
             spanCtx = req.tritonTraceSpan.context();
-            tracer = req.tritonTraceSpan.tracer()._imp._interface;
+            tracer = req.tritonTraceSpan.tracer();
 
             if (clientName) {
                 tags['client.name'] = clientName;
@@ -43,7 +44,7 @@ function child(oriClient, req, clientName) {
             ctx.tritonSpan = span;
 
             // Add headers to our outbound request
-            tracer.inject(span.context(), tracer.FORMAT_TEXT_MAP, opts.headers);
+            tracer.inject(span.context(), opentracing.FORMAT_TEXT_MAP, opts.headers);
             span.log({event: 'client-send-req'});
         }, afterSync: function _onResponse(r_err, r_req, r_res, ctx) {
             var span = ctx.tritonSpan;

--- a/lib/restify-server.js
+++ b/lib/restify-server.js
@@ -33,13 +33,13 @@ function initRestifyServer(server) {
         var span;
         var spanName = (req.route ? req.route.name : 'http_request');
 
-        extractedCtx = Tracer.extract(TritonConstants.RESTIFY_REQ_CARRIER, req);
+        extractedCtx = Tracer.globalTracer().extract(TritonConstants.RESTIFY_REQ_CARRIER, req);
         if (extractedCtx) {
             fields.continuationOf = extractedCtx;
         }
 
         // start/join a span
-        span = Tracer.startSpan(spanName, fields);
+        span = Tracer.globalTracer().startSpan(spanName, fields);
         span.addTags({
             component: 'restify',
             'http.method': req.method,
@@ -102,7 +102,7 @@ function startChildSpan(req, operation) {
     fields.childOf = req.tritonTraceSpan.context();
 
     // start then new child
-    newSpan = Tracer.startSpan(operation, fields);
+    newSpan = Tracer.globalTracer().startSpan(operation, fields);
 
     return (newSpan);
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bunyan": "^1.8.1",
     "eslint": "1.10.1",
     "node-uuid": "^1.4.7",
-    "opentracing": "^0.10.6",
+    "opentracing": "0.12.1",
     "restify": "^4.1.1",
     "restify-clients": "git+https://github.com/joshwilsdon/restify-clients.git#upstream"
   },


### PR DESCRIPTION
Upstream made more api changes and this seemed like a worthwhile learning exercise off the critical path.  This could be totally wrong, non-idiomatic js, or both.

Example Trace Before:

```
$ curl http://localhost:8090/hello/1
hello from level 1
hello from level 0
$ node examples/02-app-opentracing.js  |  node_modules/bunyan/bin/bunyan 
ExampleServer listening at http://[::]:8090
[2016-09-30T20:02:11.520Z]  INFO: ExampleServer/13013 on ys76:  (TritonTracing=TRITON, begin=1475265731220, elapsed=299, end=1475265731519, operation=do_work, parentSpanId=68f78554-c8f3-41f1-9810-89508220ea19, spanId=30e657cd-5176-416f-85bb-0f7203e89b6f, traceId=a173b435-cd24-4b43-87ac-a1d179de195c)
    logs: [
      {
        "event": "start-work",
        "timestamp": 1475265731220
      },
      {
        "event": "done-work",
        "timestamp": 1475265731519
      }
    ]
    --
    tags: {
      "random.loops": 32791343
    }
[2016-09-30T20:02:11.524Z]  INFO: ExampleServer/13013 on ys76:  (TritonTracing=TRITON, begin=1475265731220, elapsed=303, end=1475265731523, operation=gethello, spanId=68f78554-c8f3-41f1-9810-89508220ea19, traceId=a173b435-cd24-4b43-87ac-a1d179de195c)
    logs: [
      {
        "event": "server-request",
        "timestamp": 1475265731220
      },
      {
        "event": "server-response",
        "timestamp": 1475265731523
      }
    ]
    --
    tags: {
      "http.method": "GET",
      "http.url": "/hello/0",
      "http.status_code": 200,
      "restify.timers": {
        "startTracing": 192,
        "bunyan": 151,
        "respond": 302933
      }
    }
[2016-09-30T20:02:11.525Z]  INFO: ExampleServer/13013 on ys76: handled: 200 (req_id=a173b435-cd24-4b43-87ac-a1d179de195c, route=gethello, audit=true, remoteAddress=::ffff:127.0.0.1, remotePort=34724, latency=306, _audit=true, req.query="", req.version=*)
    GET /hello/0 HTTP/1.1
    accept: text/plain
    user-agent: restify/1.3.1 (x64-linux; v8/4.5.103.37; OpenSSL/1.0.2j) node/4.6.0
    accept-version: *
    date: Fri, 30 Sep 2016 20:02:11 GMT
    request-id: a173b435-cd24-4b43-87ac-a1d179de195c
    triton-span-id: 68f78554-c8f3-41f1-9810-89508220ea19
    triton-trace-enable: true
    host: 0.0.0.0:8090
    connection: close
    --
    HTTP/1.1 200 OK
    content-type: text/plain; charset=utf-8
    content-length: 20
    --
    req.timers: {
      "startTracing": 192,
      "bunyan": 151,
      "respond": 302933
    }
[2016-09-30T20:02:11.529Z]  INFO: ExampleServer/13013 on ys76:  (TritonTracing=TRITON, begin=1475265731204, elapsed=325, end=1475265731529, operation=client_request, parentSpanId=53b9ccda-ffbd-43a4-a23d-19aa756343cb, spanId=68f78554-c8f3-41f1-9810-89508220ea19, tags={}, traceId=a173b435-cd24-4b43-87ac-a1d179de195c)
    logs: [
      {
        "event": "client-request",
        "timestamp": 1475265731204
      },
      {
        "event": "client-response",
        "timestamp": 1475265731529
      }
    ]
[2016-09-30T20:02:11.531Z]  INFO: ExampleServer/13013 on ys76:  (TritonTracing=TRITON, begin=1475265731200, elapsed=331, end=1475265731531, operation=gethello, spanId=53b9ccda-ffbd-43a4-a23d-19aa756343cb, traceId=a173b435-cd24-4b43-87ac-a1d179de195c)
    logs: [
      {
        "event": "server-request",
        "timestamp": 1475265731200
      },
      {
        "event": "server-response",
        "timestamp": 1475265731531
      }
    ]
    --
    tags: {
      "http.method": "GET",
      "http.url": "/hello/1",
      "http.status_code": 200,
      "restify.timers": {
        "startTracing": 2954,
        "bunyan": 310,
        "respond": 329767
      }
    }
[2016-09-30T20:02:11.531Z]  INFO: ExampleServer/13013 on ys76: handled: 200 (req_id=a173b435-cd24-4b43-87ac-a1d179de195c, route=gethello, audit=true, remoteAddress=::1, remotePort=35332, latency=343, _audit=true, req.query="", req.version=*)
    GET /hello/1 HTTP/1.1
    user-agent: curl/7.38.0
    host: localhost:8090
    accept: */*
    --
    HTTP/1.1 200 OK
    content-type: text/plain; charset=utf-8
    content-length: 40
    --
    req.timers: {
      "startTracing": 2954,
      "bunyan": 310,
      "respond": 329767
    }
```

Example Trace After

```
$ curl localhost:8080/hello/1
hello from level 1
hello from level 0
$ node examples/02-app-opentracing.js  |  node_modules/bunyan/bin/bunyan 
ExampleServer listening at http://[::]:8080
[2016-09-30T20:02:54.774Z]  INFO: ExampleServer/13046 on ys76:  (TritonTracing=TRITON, begin=1475265774683, elapsed=90, end=1475265774773, operation=do_work, parentSpanId=0408f972-8379-4e37-8c5d-d66f6058c4d8, spanId=211ef03f-8068-4d4d-85e1-a28ac9e56007, traceId=8530c575-0c7f-4692-a60a-922ad37b3dc8)
    logs: [
      {
        "event": "start-work",
        "timestamp": 1475265774683
      },
      {
        "event": "done-work",
        "timestamp": 1475265774773
      }
    ]
    --
    tags: {
      "random.loops": 8489574
    }
[2016-09-30T20:02:54.777Z]  INFO: ExampleServer/13046 on ys76:  (TritonTracing=TRITON, begin=1475265774682, elapsed=95, end=1475265774777, operation=gethello, spanId=0408f972-8379-4e37-8c5d-d66f6058c4d8, traceId=c4bc3516-cb46-4d15-8f90-0a067a2b0739)
    logs: [
      {
        "event": "server-request",
        "timestamp": 1475265774682
      },
      {
        "event": "server-response",
        "timestamp": 1475265774777
      }
    ]
    --
    tags: {
      "http.method": "GET",
      "http.url": "/hello/0",
      "http.status_code": 200,
      "restify.timers": {
        "startTracing": 361,
        "bunyan": 339,
        "respond": 94159
      }
    }
[2016-09-30T20:02:54.779Z]  INFO: ExampleServer/13046 on ys76: handled: 200 (req_id=c4bc3516-cb46-4d15-8f90-0a067a2b0739, route=gethello, audit=true, remoteAddress=::ffff:127.0.0.1, remotePort=46078, latency=99, _audit=true, req.query="", req.version=*)
    GET /hello/0 HTTP/1.1
    accept: text/plain
    user-agent: restify/1.3.1 (x64-linux; v8/4.5.103.37; OpenSSL/1.0.2j) node/4.6.0
    accept-version: *
    date: Fri, 30 Sep 2016 20:02:54 GMT
    request-id: c4bc3516-cb46-4d15-8f90-0a067a2b0739
    triton-span-id: 0408f972-8379-4e37-8c5d-d66f6058c4d8
    triton-trace-enable: true
    host: 0.0.0.0:8080
    connection: close
    --
    HTTP/1.1 200 OK
    content-type: text/plain; charset=utf-8
    content-length: 20
    --
    req.timers: {
      "startTracing": 361,
      "bunyan": 339,
      "respond": 94159
    }
[2016-09-30T20:02:54.783Z]  INFO: ExampleServer/13046 on ys76:  (TritonTracing=TRITON, begin=1475265774645, elapsed=138, end=1475265774783, operation=client_request, parentSpanId=d36f28a7-f226-47ed-9c68-292378144985, spanId=0408f972-8379-4e37-8c5d-d66f6058c4d8, tags={}, traceId=c4bc3516-cb46-4d15-8f90-0a067a2b0739)
    logs: [
      {
        "event": "client-request",
        "timestamp": 1475265774645
      },
      {
        "event": "client-response",
        "timestamp": 1475265774783
      }
    ]
[2016-09-30T20:02:54.785Z]  INFO: ExampleServer/13046 on ys76:  (TritonTracing=TRITON, begin=1475265774637, elapsed=148, end=1475265774785, operation=gethello, spanId=d36f28a7-f226-47ed-9c68-292378144985, traceId=483a1e79-c8cf-4be2-b2b4-384ee2cbbbd5)
    logs: [
      {
        "event": "server-request",
        "timestamp": 1475265774638
      },
      {
        "event": "server-response",
        "timestamp": 1475265774785
      }
    ]
    --
    tags: {
      "http.method": "GET",
      "http.url": "/hello/1",
      "http.status_code": 200,
      "restify.timers": {
        "startTracing": 3652,
        "bunyan": 670,
        "respond": 145296
      }
    }
[2016-09-30T20:02:54.785Z]  INFO: ExampleServer/13046 on ys76: handled: 200 (req_id=483a1e79-c8cf-4be2-b2b4-384ee2cbbbd5, route=gethello, audit=true, remoteAddress=::1, remotePort=52990, latency=162, _audit=true, req.query="", req.version=*)
    GET /hello/1 HTTP/1.1
    user-agent: curl/7.38.0
    host: localhost:8080
    accept: */*
    --
    HTTP/1.1 200 OK
    content-type: text/plain; charset=utf-8
    content-length: 40
    --
    req.timers: {
      "startTracing": 3652,
      "bunyan": 670,
      "respond": 145296
    }
```
